### PR TITLE
Support multiple firehose delivery streams

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -17,7 +17,7 @@ firehose:
     accessKeyId:
     secretAccessKey:
     region:
-    stream:
+    streams: # must be an array
 
 appenders:
     - type: file

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -17,7 +17,7 @@ firehose:
     accessKeyId:
     secretAccessKey:
     region:
-    stream:
+    streams: # must be an array
 
 appenders:
     - type: file

--- a/database.js
+++ b/database.js
@@ -61,17 +61,19 @@ module.exports = function(config) {
       }
 
       if (firehose) {
-        firehose.putRecord({
-          DeliveryStreamName: config.firehose.stream, /* required */
-          Record: {
-            Data: JSON.stringify(lower(item))
-          },
-        }, function(err, data) {
-          if (err) {
-            console.log("Error firehosing data: ", err, JSON.stringify(lower(item)));
-          } else {
-            console.log("Successfully firehosed data");
-          }
+        config.firehose.streams.forEach(function (stream) {
+          firehose.putRecord({
+            DeliveryStreamName: stream, /* required */
+            Record: {
+              Data: JSON.stringify(lower(item))
+            },
+          }, function(err, data) {
+            if (err) {
+              console.log("Error firehosing data: ", err, JSON.stringify(lower(item)));
+            } else {
+              console.log("Successfully firehosed data");
+            }
+          });
         });
       }
     },


### PR DESCRIPTION
Seeing as Firehose only supports a single destination per delivery
stream, we must support multiple delivery streams in snoop to be able to
support redshift and elasticsearch at the same time. I did this by
changing the config parameter to streams which should look like this:

```
streams:
  - rtcstats-redshift-stream
  - rtcstats-es-stream
```

Note that `stream` is removed and this requires a config change to run
correctly.

Source for my claim is:
"A delivery stream can only be configured with a single destination,
Amazon S3, Amazon Elasticsearch Service, or Amazon Redshift. For correct
CreateDeliveryStream request syntax, specify only one destination
configuration parameter: either S3DestinationConfiguration,
ElasticsearchDestinationConfiguration, or
RedshiftDestinationConfiguration."
- http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Firehose.html#createDeliveryStream-property
