### PR TITLE
Docker: Run npm install as the app user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,16 +4,22 @@ MAINTAINER Tokbox <ops@tokbox.com>
 ENV app rtcstats-server
 
 RUN useradd $app \
+  && mkdir /home/$app \
+  && chown $app:$app /home/$app \
   && mkdir -p /var/log/$app /$app \
   && chown $app:$app /var/log/$app /$app
 WORKDIR /$app
 COPY . /$app
+
+RUN chown -R $app:$app /$app
+
+USER $app
+
 RUN npm install
 
 # Generate static/rtcstats.min.js
 RUN mkdir static && cd node_modules/rtcstats && npm run dist && cp min.js ../../static/rtcstats.min.js
 
-USER $app
 VOLUME ["/var/log/$app"]
 EXPOSE 3000
 CMD ["npm", "start"]


### PR DESCRIPTION
This fixes the issue that prevented downloading the maxmind database