### PR TITLE
extract: data.time is not a thing

### DIFF
--- a/extract.js
+++ b/extract.js
@@ -123,7 +123,7 @@ fs.readFile(path, {encoding: 'utf-8'}, function(err, data) {
         lines.forEach(function(line) {
             if (line.length) {
                 var data = JSON.parse(line);
-                var time = new Date(data.time)
+                var time = new Date(data.time || data[3])
                 delete data.time;
                 switch(data[0]) {
                 case 'location':


### PR DESCRIPTION
since in the change to copy args in
    https://github.com/opentok/rtcstats/pull/33
the serialized argument is an array, not an object.

(internally some stuff like the metadata is still an object though)