### PR TITLE
feature: ensure sessionduration > 0

### DIFF
--- a/features.js
+++ b/features.js
@@ -1271,9 +1271,12 @@ module.exports = {
         }
         if (startTime > 0) {
             // TODO: this is too simplistic. What if the ice connection state went to failed?
-            endTime = new Date(peerConnectionLog[peerConnectionLog.length - 1].time).getTime();
-            if (endTime > 0) {
-                return endTime - startTime;
+            for (var j = peerConnectionLog.length - 1; j > i; j--) {
+                endTime = new Date(peerConnectionLog[j].time).getTime();
+                console.log(startTime, endTime);
+                if (startTime < endTime && endTime > 0) {
+                    return endTime - startTime;
+                }
             }
         }
     },


### PR DESCRIPTION
i have seen quite some instances of sessionDuration
being negative due to timestamps switching from 2017 to 1980.
This guards against this.

```
["getstats","PC_0",{"ssrc_495244175_recv":{"googDecodingCTN":"102668","packetsReceived":"51210","googPreferredJitterBufferMs":"140","googDecodingNormal":"101099","googAccelerateRate":"0.00744629","bytesReceived":"1194406","googCurrentDelayMs":"273","googCaptureStartNtpTimeMs":"3703941555357","googJitterBufferMs":"195"},"ssrc_3094228494_recv":{"googCaptureStartNtpTimeMs":"3703941555590","googTargetDelayMs":"183","packetsReceived":"58349","googFrameRateReceived":"5","qpSum":"105900","framesDecoded":"6268","bytesReceived":"64346755","googCurrentDelayMs":"135","googMinPlayoutDelayMs":"183","googJitterBufferMs":"96"},"bweforvideo":{"googActualEncBitrate":"95590","googBucketDelay":"3","googTransmitBitrate":"97392"},"Conn-audio-1-0":{"responsesSent":"409","requestsReceived":"409","requestsSent":"420","googRtt":"138","bytesReceived":"66705998","responsesReceived":"412","bytesSent":"40554798","packetsSent":"106106"},"Conn-audio-1-1":{"googReadable":"false"},"ssrc_985921125_send":{"audioInputLevel":"28","googRtt":"90","googJitterReceived":"16","packetsSent":"51349","bytesSent":"1191136"},"ssrc_1625492663_send":{"googRtt":"104","googEncodeUsagePercent":"16","googAvgEncodeMs":"6","framesEncoded":"16868","qpSum":"695592","packetsSent":"42131","bytesSent":"38404821"},"timestamp":"2017-05-16T16:56:22.432Z"},1494953782432]
["getstats","PC_0",{"timestamp":"1980-05-16T16:56:24.489Z"},327344184489]
```