### PR TITLE
update dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM node:4
-MAINTAINER Tokbox <ops@tokbox.com>
+FROM node:6
 
 ENV app rtcstats-server
 
@@ -16,9 +15,6 @@ RUN chown -R $app:$app /$app
 USER $app
 
 RUN npm install
-
-# Generate static/rtcstats.min.js
-RUN mkdir static && cd node_modules/rtcstats && npm run dist && cp min.js ../../static/rtcstats.min.js
 
 VOLUME ["/var/log/$app"]
 EXPOSE 3000

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "maxmind": "^1.3.0",
     "pem": "^1.8.1",
     "platform": "https://github.com/bestiejs/platform.js.git",
-    "rtcstats": "https://github.com/opentok/rtcstats.git",
     "sdp": "^1.0.0",
     "uuid": "^2.0.1",
     "ws": "^5.1.1"


### PR DESCRIPTION
using node6 as base. Also the current version no longer attempts to
serve the bundled rtcstats.js