### PR TITLE
feature: add local network type to firstcandidatepair

### DIFF
--- a/features.js
+++ b/features.js
@@ -1422,7 +1422,8 @@ module.exports = {
                         localIPAddress: localCandidate.ipAddress,
                         remoteIPAddress: remoteCandidate.ipAddress,
                         localTypePreference: localCandidate.priority >> 24,
-                        remoteTypePreference: remoteCandidate.priority >> 24
+                        remoteTypePreference: remoteCandidate.priority >> 24,
+                        localNetworkType: localCandidate.networkType
                     };
                 }
             });


### PR DESCRIPTION
'cause VPN... in particular this:
{"id":"Cand-/MldeHxA","timestamp":1537546468878,"type":"localcandidate","portNumber":"59322",
    "networkType":"vpn",
    "ipAddress":"y.y.y.x","transport":"udp","candidateType":"peerreflexive","priority":"1853759231"}