### PR TITLE
add feature measuring how long a track is actively sending or receiving data

### DIFF
--- a/extract.js
+++ b/extract.js
@@ -97,7 +97,7 @@ function generateFeatures(url, client, clientid) {
             const streamFeatures = {streamId};
             for (const {trackId, kind, direction, stats} of tracks) {
                 Object.keys(streamfeatures).forEach(fname => {
-                    let feature = streamfeatures[fname].apply(null, [{kind, direction, trackId, stats}]);
+                    let feature = streamfeatures[fname].apply(null, [{kind, direction, trackId, stats, peerConnectionLog: conn}]);
                     if (feature !== undefined) {
                         feature = safeFeature(feature);
                         if (typeof feature === 'object') {

--- a/features-stream.js
+++ b/features-stream.js
@@ -20,6 +20,19 @@ module.exports = {
         const last = stats[stats.length - 1];
         return last.timestamp.getTime() - first.timestamp.getTime();
     },
+    active: ({kind, direction, trackId, stats}) => {
+        if (stats.length < 2) {
+            return 0;
+        }
+        const statName = direction === 'send' ? 'bytesSent' : 'bytesReceived';
+        let duration = 0;
+        for (let i = 1; i < stats.length; i++) {
+            if (stats[i][statName] !== stats[i - 1][statName]) {
+                duration += stats[i].timestamp.getTime() - stats[i - 1].timestamp.getTime();
+            }
+        }
+        return duration;
+    },
 };
 
 /* these features operate on stats of each track, in send and recv direction */


### PR DESCRIPTION
defined by an increase in bytesReceived/bytes.
This doesn't work with unified plan because of
  https://bugs.chromium.org/p/chromium/issues/detail?id=943493
which breaks our correlation between stats and ontrack